### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 # will be cached unless changes to one of those two files
 # are made.
 COPY Gemfile Gemfile.lock ./
-RUN gem install bundler && bundle install --jobs 20 --retry 5
+RUN gem install bundler -v 1.11.2 && bundle install --jobs 20 --retry 5
 
 # Copy the main application.
 COPY . ./


### PR DESCRIPTION
Fix bundler version because of the error at docker-compose call and further errors.
"rails (4.2.7.1) has dependency bundler (< 2.0, >= 1.3.0), which is unsatisfied by the current bundler version 2.1.4, so the dependency is being ignored"