### PR TITLE
Specified the bundler version, to fix docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 # will be cached unless changes to one of those two files
 # are made.
 COPY Gemfile Gemfile.lock ./
-RUN gem install bundler && bundle install --jobs 20 --retry 5
+RUN gem install bundler -v=1.11.2 && bundle install --jobs 20 --retry 5
 
 # Copy the main application.
 COPY . ./


### PR DESCRIPTION
### The issue:
Using the current Dockerfile, the deployment fails on the installation of "bundler".

### The solution:
Specifying the exact bundler-version used (v1.11.2) allows the "docker-compose build" to run smoothly again. 

### Update in Dockerfile:
`Line 21: RUN gem install bundler -v=1.11.2 && bundle install --jobs 20 --retry 5`